### PR TITLE
Remove 'None' string from Conan OS

### DIFF
--- a/conan/stm32
+++ b/conan/stm32
@@ -1,7 +1,6 @@
 [build_requires]
 gcc-arm-none-eabi/7.3.1@wsbu/stable
 [settings]
-os=None
 os_build=Linux
 arch=armv7hf
 arch_build=x86_64

--- a/docker-stm32
+++ b/docker-stm32
@@ -22,4 +22,4 @@ docker run -it --rm \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "$HOME/.conan/registry.json:/home/captain/.conan/registry.json" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-stm32:v2.0.1 "$@"
+    wsbu/toolchain-stm32:v2.0.2 "$@"


### PR DESCRIPTION
I got schooled in Conan this morning and found out that an OS value of `None` in Conan's `settings.yml` file actually gets treated specially and should NOT be used as the string value `"None"` in Conan profiles and recipes. Once `None` is added to the settings file, you can just check `if not self.settings.os` in recipes rather than `if "None" == self.settings.os`.