### PR TITLE
Upgrade upstream Docker image to pull newer Conan version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wsbu/toolchain-native:v0.3.1
+FROM wsbu/toolchain-native:v0.3.2
 
 COPY conan/stm32 "${HOME}/.conan/profiles/stm32"
 RUN ln -sf stm32 "${HOME}/.conan/profiles/default"

--- a/docker-stm32
+++ b/docker-stm32
@@ -22,4 +22,4 @@ docker run -it --rm \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "$HOME/.conan/registry.json:/home/captain/.conan/registry.json" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-stm32:v2.0.2 "$@"
+    wsbu/toolchain-stm32:v2.0.3 "$@"


### PR DESCRIPTION
The error that occurred in this build (https://ci.redlion.net/viewLog.html?buildId=9342&buildTypeId=ManticoreIOModule_Build) is due to a known bug in Conan. I fixed it in toolchain-native and linaro but did not get around to updating this image yet.