### PR TITLE
[MAN-1574] Update upstream Docker image for new Conan version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wsbu/toolchain-native:v0.3.4
+FROM wsbu/toolchain-native:v0.3.5
 
 COPY conan/stm32 "${HOME}/.conan/profiles/stm32"
 RUN ln -sf stm32 "${HOME}/.conan/profiles/default"

--- a/docker-stm32
+++ b/docker-stm32
@@ -33,4 +33,4 @@ docker run -it --rm \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "${HOME}/.conan/remotes.json:/home/captain/.conan/remotes.json" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-stm32:v2.0.4 "$@"
+    wsbu/toolchain-stm32:v2.0.5 "$@"


### PR DESCRIPTION
Yet another Docker image that needs the new Conan version.
This one is used for building manticore-io
